### PR TITLE
feat: close not hide

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -143,9 +143,9 @@ fn main() {
                             And then proceed to try to create the menu.
                         */
                         Ok(desk) => {
-                            main_window
-                                .hide()
-                                .expect("Error while closing the initial window");
+                            // main_window
+                            //     .close()
+                            //     .expect("Error while closing the initial window");
                             // Register all shortcuts
                             let mut shortcut_manager = app.global_shortcut_manager();
                             let all_positions = &config.saved_positions;
@@ -258,16 +258,6 @@ fn main() {
                 So, when we detected an exit requested, just to be safe, refresh the system tray.
                 TODO: We should probably have a way of checking for new elements, to remove redundant system tray refreshes
             */
-            tauri::RunEvent::WindowEvent { label: _, event: window_event, .. } => match window_event {
-                tauri::WindowEvent::CloseRequested { api, .. } => {
-                    // Whenever a close is clicked, we are not actually closing the window, but hiding it. 
-                    // Why? Cause https://github.com/tauri-apps/tauri/issues/5519
-                    // Also, it's way faster and better UX to hide/show rather than open/close. 
-                    api.prevent_close();
-                    _ = app_handle.get_window("main").unwrap().hide();
-                },
-                _ => {}
-            }
             tauri::RunEvent::ExitRequested { api, .. } => {
                 println!("Exit requested");
                 let config = config_utils::get_config();

--- a/src-tauri/src/tray_utils.rs
+++ b/src-tauri/src/tray_utils.rs
@@ -1,47 +1,59 @@
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 pub fn handle_exit_menu_click() {
     std::process::exit(0);
 }
 
 pub fn handle_about_menu_click(app: &AppHandle) {
-    let main_window = app.get_window("main").unwrap();
-
-    _ = main_window.set_always_on_top(true);
-    _ = main_window.eval(
-        r#"
-        history.replaceState({}, '','/about');
-        history.go();
-"#,
-    );
-    _ = main_window.set_title("Trayasen - About/Options");
-    _ = main_window.show();
+    match tauri::WindowBuilder::new(app, "main", tauri::WindowUrl::App("index.html".into()))
+        .always_on_top(true)
+        .initialization_script(
+            r#"
+    history.replaceState({}, '','/about');
+    "#,
+        )
+        .title("Trayasen - About/Options")
+        .build()
+    {
+        Ok(_) => {}
+        Err(_) => {
+            println!("Error while trying to open about window");
+        }
+    }
 }
 
 pub fn handle_new_position_menu_click(app: &AppHandle) {
-    let main_window = app.get_window("main").unwrap();
-
-    _ = main_window.set_always_on_top(true);
-    _ = main_window.eval(
-        r#"
-        history.replaceState({}, '','/new-position');
-        history.go();
-"#,
-    );
-    _ = main_window.set_title("Trayasen - Add position");
-    _ = main_window.show();
+    match tauri::WindowBuilder::new(app, "main", tauri::WindowUrl::App("index.html".into()))
+        .always_on_top(true)
+        .initialization_script(
+            r#"
+    history.replaceState({}, '','/new-position');
+    "#,
+        )
+        .title("Trayasen - Add position")
+        .build()
+    {
+        Ok(_) => {}
+        Err(_) => {
+            println!("Error while trying to open new postition window");
+        }
+    }
 }
 
 pub fn handle_manage_positions_menu_click(app: &AppHandle) {
-    let main_window = app.get_window("main").unwrap();
-
-    _ = main_window.set_always_on_top(true);
-    _ = main_window.eval(
-        r#"
+    match tauri::WindowBuilder::new(app, "main", tauri::WindowUrl::App("index.html".into()))
+        .always_on_top(true)
+        .initialization_script(
+            r#"
     history.replaceState({}, '','/manage-positions');
-    history.go();
-"#,
-    );
-    _ = main_window.set_title("Trayasen - Manage positions");
-    _ = main_window.show();
+    "#,
+        )
+        .title("Trayasen - Manage positions")
+        .build()
+    {
+        Ok(_) => {}
+        Err(_) => {
+            println!("Error while trying to open manage positions window");
+        }
+    }
 }

--- a/src/ManagePositionsPage.tsx
+++ b/src/ManagePositionsPage.tsx
@@ -60,7 +60,7 @@ const ManagePositionsPage = () => {
         </Link>
         <Button
           onClick={() => {
-            appWindow.hide();
+            appWindow.close();
           }}
         >
           Close

--- a/src/NewPositionPage.tsx
+++ b/src/NewPositionPage.tsx
@@ -206,7 +206,7 @@ const NewPositionPage = () => {
               } else {
                 // exit cause shits been created
                 console.log("closing...");
-                appWindow.hide();
+                appWindow.close();
               }
             }
           }}


### PR DESCRIPTION
revert of https://github.com/golota60/trayasen/pull/31

turns out, hiding windows doesn't solve anything either, as there's no rust callback to notify about a window being hidden. This could've been solved by creating a custom rust command to handle the callback, but hiding windows has already been a workaround, and making a workaround on top of a workaround, is one level too deep for me.

If closing really turns out to be unsalvageable, i'll revert back to hiding. If it comes to that, i'll also need to do some perf tests on hiding vs closing, as we do not want to consume too much of end users' memory